### PR TITLE
Network performance improvement and location report

### DIFF
--- a/spreading_test.txt
+++ b/spreading_test.txt
@@ -113,6 +113,16 @@ Report.warmup = 0
 Report.reportDir = reports/
 # Report classes to load
 Report.report1 = InfectionReport
+# Configuration of parameters for the infection report
+# for each (distance, factor) pair, one entry in factor_distance, distances, in ascending order
+Report.factor_distance = 1.0, 1.0, 1.0, 0.2, 0.001
+Report.distances = 0.0, 0.5, 1.0, 1.5, 3.0
+Report.infection_rate = 0.01
+# four different factors: indoor, main stage, shisha bar and outside
+Report.factor_location = 1.0, 5.0, 10.0, 0.5
+# three values each for sender and receiver: unvaccinated, vaccinated, booster
+Report.factor_sender = 1.0, 0.9, 0.8
+Report.factor_receiver = 1.0, 0.8, 0.7
 
 Report.report2 = HostLocationReport
 

--- a/spreading_test.txt
+++ b/spreading_test.txt
@@ -119,7 +119,7 @@ Report.factor_distance = 1.0, 1.0, 1.0, 0.2, 0.001
 Report.distances = 0.0, 0.5, 1.0, 1.5, 3.0
 # infection rate between 0.0001 and 0.001 seems to produce believable results
 Report.infection_rate = 0.0025
-# four different factors: indoor, main stage, shisha bar and outside
+# four different factors: indoor, high risk party areas (indoor, main stage, metal bunker, techno bunker), shisha bar and outside
 Report.factor_location = 1.0, 5.0, 10.0, 0.5
 # three values each for sender and receiver: unvaccinated, vaccinated, booster
 Report.factor_sender = 1.0, 0.9, 0.8

--- a/spreading_test.txt
+++ b/spreading_test.txt
@@ -11,8 +11,8 @@ Scenario.endTime = 30600
 MovementModel.worldSize = 220,250
 
 firstinterface.type = InfectionSimpleBroadcastInterface
-# transmit speed of 2 Mbps = 250kBps
-firstinterface.transmitSpeed = 250k
+# transmit speed of 2 Mbps = 500kBps
+firstinterface.transmitSpeed = 500k
 firstinterface.transmitRange = 3
 
 
@@ -43,20 +43,35 @@ Group1.router = PassiveRouter
 Group1.routeFile = data/mi_magistrale_outline.wkt
 Group1.routeType = 1
 
-Group2.groupID = I2
+
+# first character defines host as I(nfected) or N(on-Infected)
+# second character denotes host as U(nvaccinated), V(accinated) or B(ooster)
+Group2.groupID = IU2
 Group2.nrofHosts = 5
 Group2.nrofInterfaces = 1
 Group2.interface1 = firstinterface
 Group2.movementModel = StatefulRwp
 
-Group3.groupID = N3
-Group3.nrofHosts = 95
+Group3.groupID = IV3
+Group3.nrofHosts = 0
 Group3.nrofInterfaces = 1
 Group3.interface1 = firstinterface
 Group3.movementModel = StatefulRwp
 
+Group4.groupID = IB4
+Group4.nrofHosts = 0
+Group4.nrofInterfaces = 1
+Group4.interface1 = firstinterface
+Group4.movementModel = StatefulRwp
+
+Group5.groupID = NU5
+Group5.nrofHosts = 95
+Group5.nrofInterfaces = 1
+Group5.interface1 = firstinterface
+Group5.movementModel = StatefulRwp
+
 # Groups
-Scenario.nrofHostGroups = 3
+Scenario.nrofHostGroups = 5
 
 
 
@@ -75,7 +90,7 @@ Events1.interval = 60,60
 # Message sizes (50kB - 150kB)
 Events1.size = 5000,5000
 # range of message source/destination addresses
-Events1.hosts = 1,5
+Events1.hosts = 1,15
 Events1.tohosts = 0,0
 # Message ID prefix
 Events1.prefix = M

--- a/spreading_test.txt
+++ b/spreading_test.txt
@@ -106,13 +106,15 @@ MovementModel.worldSize = 4500, 3400
 MovementModel.warmup = 1000
 
 # how many reports to load
-Report.nrofReports = 1
+Report.nrofReports = 2
 # length of the warm up period (simulated seconds)
 Report.warmup = 0
 # default directory of reports (can be overridden per Report with output setting)
 Report.reportDir = reports/
 # Report classes to load
 Report.report1 = InfectionReport
+
+Report.report2 = HostLocationReport
 
 ## Optimization settings -- these affect the speed of the simulation
 ## see World class for details.

--- a/spreading_test.txt
+++ b/spreading_test.txt
@@ -90,7 +90,7 @@ Events1.interval = 60,60
 # Message sizes (50kB - 150kB)
 Events1.size = 5000,5000
 # range of message source/destination addresses
-Events1.hosts = 1,15
+Events1.hosts = 1,5
 Events1.tohosts = 0,0
 # Message ID prefix
 Events1.prefix = M
@@ -117,7 +117,8 @@ Report.report1 = InfectionReport
 # for each (distance, factor) pair, one entry in factor_distance, distances, in ascending order
 Report.factor_distance = 1.0, 1.0, 1.0, 0.2, 0.001
 Report.distances = 0.0, 0.5, 1.0, 1.5, 3.0
-Report.infection_rate = 0.01
+# infection rate between 0.0001 and 0.001 seems to produce believable results
+Report.infection_rate = 0.0025
 # four different factors: indoor, main stage, shisha bar and outside
 Report.factor_location = 1.0, 5.0, 10.0, 0.5
 # three values each for sender and receiver: unvaccinated, vaccinated, booster

--- a/spreading_test.txt
+++ b/spreading_test.txt
@@ -10,7 +10,7 @@ Scenario.updateInterval = 5
 Scenario.endTime = 30600
 MovementModel.worldSize = 220,250
 
-firstinterface.type = SimpleBroadcastInterface
+firstinterface.type = InfectionSimpleBroadcastInterface
 # transmit speed of 2 Mbps = 250kBps
 firstinterface.transmitSpeed = 250k
 firstinterface.transmitRange = 3
@@ -49,7 +49,7 @@ Group2.nrofInterfaces = 1
 Group2.interface1 = firstinterface
 Group2.movementModel = StatefulRwp
 
-Group3.groupID = 3
+Group3.groupID = N3
 Group3.nrofHosts = 95
 Group3.nrofInterfaces = 1
 Group3.interface1 = firstinterface
@@ -68,14 +68,14 @@ Scenario.nrofHostGroups = 3
 # How many event generators
 Events.nrof = 1
 # Class of the first event generator
-Events1.class = SingleMessageGenerator
+Events1.class = MessageBurstGenerator
 # (following settings are specific for the MessageEventGenerator class)
 # Creation interval in seconds (one new message every 25 to 35 seconds)
 Events1.interval = 60,60
 # Message sizes (50kB - 150kB)
 Events1.size = 5000,5000
 # range of message source/destination addresses
-Events1.hosts = 1,9
+Events1.hosts = 1,5
 Events1.tohosts = 0,0
 # Message ID prefix
 Events1.prefix = M

--- a/src/input/MessageBroadcastCreateEvent.java
+++ b/src/input/MessageBroadcastCreateEvent.java
@@ -41,7 +41,6 @@ public class MessageBroadcastCreateEvent extends ExternalEvent {
         for (int i = this.receivers[0]; i <= this.receivers[1]; i++) {
             DTNHost to = world.getNodeByAddress(i);
             DTNHost from = world.getNodeByAddress(this.fromAddr);
-            // TODO Configure range for message creation
             if(to.getLocation().distance(from.getLocation()) < 10){
                 Message m = new Message(from, to, this.id, this.size);
                 m.setResponseSize(this.responseSize);

--- a/src/input/MessageBroadcastGenerator.java
+++ b/src/input/MessageBroadcastGenerator.java
@@ -50,7 +50,6 @@ public class MessageBroadcastGenerator extends MessageEventGenerator {
             to = this.toHostRange[0] + (++nextToOffset);
         }
         // message size depends on host: vaccinated, wears mask, indoor/outdoor
-        // TODO: change to variable size
         msgSize = 1000;
         MessageBroadcastCreateEvent mce = new MessageBroadcastCreateEvent(from, this.toHostRange, getID(),
                 msgSize, responseSize, this.nextEventsTime);

--- a/src/interfaces/InfectionSimpleBroadcastInterface.java
+++ b/src/interfaces/InfectionSimpleBroadcastInterface.java
@@ -1,0 +1,145 @@
+package interfaces;
+
+import core.CBRConnection;
+import core.Connection;
+import core.NetworkInterface;
+import core.Settings;
+
+import java.util.Collection;
+
+
+/*
+ * Copyright 2010 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+import java.util.Collection;
+
+import core.CBRConnection;
+import core.Connection;
+import core.NetworkInterface;
+import core.Settings;
+
+/**
+ * A simple Network Interface that provides a constant bit-rate service, where
+ * one transmission can be on at a time.
+ * Change compared to SimpleBroadcastInterface: Only host interfaces with different infection status (non-infected or infected) will connect to each other.
+ * Infection status is indicated with the first character of the group id (N(ot infected) or I(nfected))
+ */
+public class InfectionSimpleBroadcastInterface extends NetworkInterface {
+
+    /**
+     * Reads the interface settings from the Settings file
+     */
+    public InfectionSimpleBroadcastInterface(Settings s)	{
+        super(s);
+    }
+
+    /**
+     * Copy constructor
+     * @param ni the copied network interface object
+     */
+    public InfectionSimpleBroadcastInterface(InfectionSimpleBroadcastInterface ni) {
+        super(ni);
+    }
+
+    public NetworkInterface replicate()	{
+        return new InfectionSimpleBroadcastInterface(this);
+    }
+
+    /**
+     * Tries to connect this host to another host. The other host must be
+     * active and within range of this host for the connection to succeed.
+     * @param anotherInterface The interface to connect to
+     */
+    public void connect(NetworkInterface anotherInterface) {
+        //System.out.println(getHost().toString().charAt(0) + "," + anotherInterface.getHost().toString().charAt(0));
+        if(getHost().toString().charAt(0) == anotherInterface.getHost().toString().charAt(0)){
+            // first character is the same ==> same infection status and don't connect
+            return;
+        }
+        if (isScanning()
+                && anotherInterface.getHost().isRadioActive()
+                && isWithinRange(anotherInterface)
+                && !isConnected(anotherInterface)
+                && (this != anotherInterface)) {
+            // new contact within range
+            // connection speed is the lower one of the two speeds
+            int conSpeed = anotherInterface.getTransmitSpeed(this);
+            if (conSpeed > this.transmitSpeed) {
+                conSpeed = this.transmitSpeed;
+            }
+
+            Connection con = new CBRConnection(this.host, this,
+                    anotherInterface.getHost(), anotherInterface, conSpeed);
+            connect(con,anotherInterface);
+        }
+    }
+
+    /**
+     * Updates the state of current connections (i.e. tears down connections
+     * that are out of range and creates new ones).
+     */
+    public void update() {
+        if (optimizer == null) {
+            return; /* nothing to do */
+        }
+
+        // First break the old ones
+        optimizer.updateLocation(this);
+        for (int i=0; i<this.connections.size(); ) {
+            Connection con = this.connections.get(i);
+            NetworkInterface anotherInterface = con.getOtherInterface(this);
+
+            // all connections should be up at this stage
+            assert con.isUp() : "Connection " + con + " was down!";
+
+            if (!isWithinRange(anotherInterface)) {
+                disconnect(con,anotherInterface);
+                connections.remove(i);
+            }
+            else {
+                i++;
+            }
+        }
+        // Then find new possible connections
+        Collection<NetworkInterface> interfaces =
+                optimizer.getNearInterfaces(this);
+        for (NetworkInterface i : interfaces) {
+            connect(i);
+        }
+    }
+
+    /**
+     * Creates a connection to another host. This method does not do any checks
+     * on whether the other node is in range or active
+     * @param anotherInterface The interface to create the connection to
+     */
+    public void createConnection(NetworkInterface anotherInterface) {
+        if(getHost().toString().charAt(0) == anotherInterface.getHost().toString().charAt(0)){
+            // first character is the same ==> same infection status and don't connect
+            //System.out.println(getHost().toString().charAt(0) + "," + anotherInterface.getHost().toString().charAt(0));
+            return;
+        }
+        if (!isConnected(anotherInterface) && (this != anotherInterface)) {
+            // connection speed is the lower one of the two speeds
+            int conSpeed = anotherInterface.getTransmitSpeed(this);
+            if (conSpeed > this.transmitSpeed) {
+                conSpeed = this.transmitSpeed;
+            }
+
+            Connection con = new CBRConnection(this.host, this,
+                    anotherInterface.getHost(), anotherInterface, conSpeed);
+            connect(con,anotherInterface);
+        }
+    }
+
+    /**
+     * Returns a string representation of the object.
+     * @return a string representation of the object.
+     */
+    public String toString() {
+        return "InfectionSimpleBroadcastInterface " + super.toString();
+    }
+
+}

--- a/src/interfaces/InfectionSimpleBroadcastInterface.java
+++ b/src/interfaces/InfectionSimpleBroadcastInterface.java
@@ -1,13 +1,5 @@
 package interfaces;
 
-import core.CBRConnection;
-import core.Connection;
-import core.NetworkInterface;
-import core.Settings;
-
-import java.util.Collection;
-
-
 /*
  * Copyright 2010 Aalto University, ComNet
  * Released under GPLv3. See LICENSE.txt for details.

--- a/src/report/HostLocationReport.java
+++ b/src/report/HostLocationReport.java
@@ -1,0 +1,161 @@
+package report;
+
+import core.Coord;
+import core.DTNHost;
+import core.UpdateListener;
+import movement.state.states.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Class that maps all hosts in the simulation to a given area in the Unity Simulation
+ */
+public class HostLocationReport
+    extends Report
+    implements UpdateListener {
+
+
+    private static final NodeState[] states = new NodeState[]{
+            new QueueState(),
+            new EntryState(),
+            new WardrobeState(),
+            new MainStageState(),
+            new OutdoorAreaState(),
+            new MetalBunkerState(),
+            new TechnoBunkerState(),
+            new CocktailBarState(),
+            new BeerBarState(),
+            new ShotBarState(),
+            new ShishaBarState(),
+            new PizzaBarState(),
+            new SideWCState(),
+            new MainWCState(),
+            new ExitState(),
+            new WardrobeBeforeLeavingState()
+    };
+
+    public HostLocationReport(){
+        init();
+    }
+
+    @Override
+    public void init(){
+        super.init();
+        // write all labels into first row
+        Optional<String> optRow = Arrays.stream(states).map(NodeState::getStateName).reduce((a, b)->a + "," + b);
+        if(optRow.isPresent()){
+            String firstRow = "Time step," + optRow.get() + "," + "Other";
+            write(firstRow);
+        }
+
+    }
+
+    @Override
+    public void updated(List<DTNHost> hosts) {
+        // at each time step, record amount of nodes at each area
+        int[] amount = new int[states.length + 1];
+        for(DTNHost host: hosts){
+            boolean locationFound = false;
+            for(int i = 0; i < states.length; i++){
+                if(isInside(states[i].getPolygon(), host.getLocation())){
+                    amount[i]++;
+                    locationFound = true;
+                    break;
+                }
+            }
+            if(!locationFound){
+                amount[amount.length - 1]++; // Count host to "Other" tag
+            }
+        }
+        StringBuilder builder = new StringBuilder();
+        builder.append(getSimTime());
+        for (int j : amount) {
+            builder.append(",");
+            builder.append(j);
+        }
+        write(builder.toString());
+    }
+
+    @Override
+    public void done() {
+        super.done();
+    }
+
+
+    //--------------- methods from ProhibitedPolygonRwp, methods needed to map point to a certain area on the map -------------
+
+    private static boolean isInside(
+            final List <Coord> polygon,
+            final Coord point ) {
+        final int count = countIntersectedEdges( polygon, point,
+                new Coord( -10,0 ) );
+        return ( ( count % 2 ) != 0 );
+    }
+
+    private static int countIntersectedEdges(
+            final List<Coord> polygon,
+            final Coord start,
+            final Coord end ) {
+        int count = 0;
+        for ( int i = 0; i < polygon.size() - 1; i++ ) {
+            final Coord polyP1 = polygon.get( i );
+            final Coord polyP2 = polygon.get( i + 1 );
+
+            final Coord intersection = intersection( start, end, polyP1, polyP2 );
+            if ( intersection == null ) continue;
+
+            if ( isOnSegment( polyP1, polyP2, intersection )
+                    && isOnSegment( start, end, intersection ) ) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean isOnSegment(
+            final Coord L0,
+            final Coord L1,
+            final Coord point ) {
+        final double crossProduct
+                = ( point.getY() - L0.getY() ) * ( L1.getX() - L0.getX() )
+                - ( point.getX() - L0.getX() ) * ( L1.getY() - L0.getY() );
+        if ( Math.abs( crossProduct ) > 0.0000001 ) return false;
+
+        final double dotProduct
+                = ( point.getX() - L0.getX() ) * ( L1.getX() - L0.getX() )
+                + ( point.getY() - L0.getY() ) * ( L1.getY() - L0.getY() );
+        if ( dotProduct < 0 ) return false;
+
+        final double squaredLength
+                = ( L1.getX() - L0.getX() ) * ( L1.getX() - L0.getX() )
+                + (L1.getY() - L0.getY() ) * (L1.getY() - L0.getY() );
+        return !(dotProduct > squaredLength);
+    }
+
+    private static Coord intersection(
+            final Coord L0_p0,
+            final Coord L0_p1,
+            final Coord L1_p0,
+            final Coord L1_p1 ) {
+        final double[] p0 = getParams( L0_p0, L0_p1 );
+        final double[] p1 = getParams( L1_p0, L1_p1 );
+        final double D = p0[ 1 ] * p1[ 0 ] - p0[ 0 ] * p1[ 1 ];
+        if ( D == 0.0 ) return null;
+
+        final double x = ( p0[ 2 ] * p1[ 1 ] - p0[ 1 ] * p1[ 2 ] ) / D;
+        final double y = ( p0[ 2 ] * p1[ 0 ] - p0[ 0 ] * p1[ 2 ] ) / D;
+
+        return new Coord( x, y );
+    }
+
+    private static double[] getParams(
+            final Coord c0,
+            final Coord c1 ) {
+        final double A = c0.getY() - c1.getY();
+        final double B = c0.getX() - c1.getX();
+        final double C = c0.getX() * c1.getY() - c0.getY() * c1.getX();
+        return new double[] { A, B, C };
+    }
+}

--- a/src/report/InfectionReport.java
+++ b/src/report/InfectionReport.java
@@ -37,6 +37,7 @@ public class InfectionReport
     private static final int INDEX_BOOSTER = 2;
     // constants
     private double prob;
+    private static final boolean showDebugOutput = false;
 
     private static final NodeState[] states = new NodeState[]{
             new QueueState(),
@@ -92,40 +93,40 @@ public class InfectionReport
         double[] distancesDefault = new double[]{0.0, 0.5, 1.0, 1.5, 3.0};
         if(getSettings().contains(FACTOR_DISTANCE_S)) {
             factorDistances = getSettings().getCsvDoubles(FACTOR_DISTANCE_S);
-            System.out.println("Applied config settings for factorDistances");
+            if(showDebugOutput) System.out.println("Applied config settings for factorDistances");
         }else{
             factorDistances = factorDistancesDefault;
         }
         if(getSettings().contains(DISTANCES_S)){
             distances = getSettings().getCsvDoubles(DISTANCES_S);
-            System.out.println("Applied config settings for distances");
+            if(showDebugOutput) System.out.println("Applied config settings for distances");
         }else{
             distances = distancesDefault;
         }
         if(getSettings().contains(INFECTION_PROB_S) && getSettings().getDouble(INFECTION_PROB_S) >= 0 && getSettings().getDouble(INFECTION_PROB_S) <= 1){
             prob = getSettings().getDouble(INFECTION_PROB_S);
-            System.out.println("Applied config settings for infection rate");
+            if (showDebugOutput) System.out.println("Applied config settings for infection rate");
         }else{
             prob = 0.005;
         }
         // factor location: Indoor, main stage, shisha bar, outside
         if(getSettings().contains(FACTOR_LOCATION_S)){
             factorLocation = getSettings().getCsvDoubles(FACTOR_LOCATION_S, 4);
-            System.out.println("Applied config settings for factor location");
+            if(showDebugOutput) System.out.println("Applied config settings for factor location");
         }else{
             factorLocation = new double[]{1.0, 5.0, 10.0, 0.5};
         }
         // factor sender: unvaccinated, vaccinated, booster
         if(getSettings().contains(FACTOR_SENDER_S)){
             factorSender = getSettings().getCsvDoubles(FACTOR_SENDER_S, 3);
-            System.out.println("Applied config settings for factor sender");
+            if(showDebugOutput) System.out.println("Applied config settings for factor sender");
         }else{
             factorSender = new double[]{1.0, 0.8, 0.7};
         }
         // factor receiver: unvaccinated, vaccinated, booster
         if(getSettings().contains(FACTOR_RECEIVER_S)){
             factorReceiver = getSettings().getCsvDoubles(FACTOR_RECEIVER_S, 3);
-            System.out.println("Applied config settings for factor receiver");
+            if(showDebugOutput) System.out.println("Applied config settings for factor receiver");
         }else{
             factorReceiver = new double[]{1.0, 0.9, 0.8};
         }


### PR DESCRIPTION
- Added HostLocationReport that maps all hosts to one of 17 areas (16 states + Other) in the simulation
> Time step,Queue,Entry,Wardrobe,Main Stage,Outdoor Area,Metal Bunker,Techno Bunker,Cocktail Bar,Beer Bar,Shot Bar,Shisha Bar,Pizza Bar,Side WC,Main WC,Exit,Wardrobe before leaving,Other
2375.0,178,185,333,51,18,13,9,7,174,5,4,11,3,9,0,0,6

- Improved performance for simulations significantly, people with the same infection status won't connect to each other anymore (at least10x faster for larger simulations)
- Added InfectionReport parameter configuration in setting file